### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
   pull_request:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Show Xcode version
         run: xcodebuild -version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Build and test
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Run tests
+        run: |
+          set -o pipefail
+          DEVICE=$(xcrun simctl list devices available -j \
+            | jq -r '[.devices[] | .[] | select(.name | test("^iPhone"))][0].name')
+          echo "Using simulator: $DEVICE"
+          xcodebuild -project "OST Tracker.xcodeproj" -scheme "OST Remote 2" \
+            -destination "platform=iOS Simulator,name=$DEVICE" \
+            test


### PR DESCRIPTION
Adds a CI workflow that builds the app and runs the full 200-test suite on every pull request, using GitHub's free macOS runners (free because this repo is public).

Details:
- Simulator tests need no code signing, so no secrets or certificates are required.
- The iPhone simulator is selected dynamically from whatever the runner image provides, so GitHub image updates won't break the workflow.
- Concurrent runs on the same branch cancel superseded ones.

This PR itself will be the workflow's first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)